### PR TITLE
fix JSON map dependencies and support Tiled 1.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ fxconv_declare_converters(assets-cg/converters.py)
 
 add_custom_command(
 	OUTPUT "${CMAKE_CURRENT_LIST_DIR}/assets-cg/maps/testCarte.json"
+	       "${CMAKE_CURRENT_LIST_DIR}/assets-cg/maps/1.json"
+	       "${CMAKE_CURRENT_LIST_DIR}/assets-cg/maps/2.json"
 	       "${CMAKE_CURRENT_LIST_DIR}/assets-cg/maps/inside/1.json"
 	       "${CMAKE_CURRENT_LIST_DIR}/assets-cg/maps/inside/2.json"
 	COMMENT "Convert tmx map to json"

--- a/assets-cg/converters.py
+++ b/assets-cg/converters.py
@@ -73,7 +73,7 @@ def convert_map(input, output, params, target):
 	#create a dictionnary {tile id:type}
 	for i in data_tileset["tiles"]:
 		id = i["id"]+1
-		type = i["type"]
+		type = i["class"] if "class" in i else i["type"]
 
 		value = tile_type.get(type) if type in tile_type else TILE_AIR
 		tile_value[id] = value


### PR DESCRIPTION
Adds some missing map dependencies in the generation command. Not having them means that CMake is unable to determine that `assets-cg/maps/*.json` is generated by this command, so it complains about missing source files.

Also, starting with Tiled 1.9 [the type of tiles is now called `"class"`](https://github.com/mapeditor/tiled/blob/master/src/libtiled/maptovariantconverter.cpp#L292-L295), so I updated the converter to support that (without breaking compatibility with earlier versions). Some distributions already ship Tiled 1.9, so the previous script would simply fail to parse the tileset data.